### PR TITLE
fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ nnoremap <leader>S <cmd>lua require('spectre').open()<CR>
 nnoremap <leader>sw <cmd>lua require('spectre').open_visual({select_word=true})<CR>
 vnoremap <leader>s <esc>:lua require('spectre').open_visual()<CR>
 "  search in current file
-nnoremap <leader>sp viw:lua require('spectre').open_file_search()<cr>
+nnoremap <leader>sp <cmd>lua require('spectre').open_file_search()<cr>
 " run command :Spectre
 ```
 


### PR DESCRIPTION
Fix typo in mappings.
`viw:` makes no sense, there should be `<cmd>` instead, I belive.
Sry if I misunderstood something.