### PR TITLE
Fix preview and close Help menu

### DIFF
--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -545,12 +545,10 @@ M.change_options = function(key)
         state.options[key] = false
     end
     state.options[key] = not state.options[key]
-    pcall(function()
-        if #state.query.search_query > 0 then
-            ui.render_search_ui()
-            M.search()
-        end
-    end)
+    if state.query.search_query ~= nil then
+        ui.render_search_ui()
+        M.search()
+    end
 end
 
 M.show_options = function()

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -545,10 +545,12 @@ M.change_options = function(key)
         state.options[key] = false
     end
     state.options[key] = not state.options[key]
-    if #state.query.search_query > 0 then
-        ui.render_search_ui()
-        M.search()
-    end
+    pcall(function()
+        if #state.query.search_query > 0 then
+            ui.render_search_ui()
+            M.search()
+        end
+    end)
 end
 
 M.show_options = function()

--- a/lua/spectre/ui.lua
+++ b/lua/spectre/ui.lua
@@ -144,39 +144,10 @@ function M.render_header(opts)
     utils.write_virtual_text(state.bufnr, config.namespace_header, 0, { { help_text, 'Comment' } })
 end
 
----@private
---- Creates autocommands to close a preview window when events happen.
----
----@param events table list of events
----@param winnr number window id of preview window
----@param bufnrs table list of buffers where the preview window will remain visible
----@see |autocmd-events|
-local function close_preview_autocmd(events, winnr, bufnrs)
-    local augroup = 'preview_window_' .. winnr
-
-    -- close the preview window when entered a buffer that is not
-    -- the floating window buffer or the buffer that spawned it
-    vim.cmd(string.format([[
-    augroup %s
-      autocmd!
-      autocmd BufEnter * lua vim.lsp.util._close_preview_window(%d, {%s})
-    augroup end
-  ]] , augroup, winnr, table.concat(bufnrs, ',')))
-
-    if #events > 0 then
-        vim.cmd(string.format([[
-      augroup %s
-        autocmd %s <buffer> lua vim.lsp.util._close_preview_window(%d)
-      augroup end
-    ]]   , augroup, table.concat(events, ','), winnr))
-    end
-end
-
 M.show_menu_options = function(title, content)
     local win_width, win_height = vim.lsp.util._make_floating_popup_size(content, {})
     local help_win, preview = popup.create(content, {
         title   = title,
-        border  = true,
         padding = { 1, 1, 1, 1 },
         enter   = false,
         width   = win_width + 2,
@@ -186,11 +157,10 @@ M.show_menu_options = function(title, content)
     })
 
     vim.api.nvim_win_set_option(help_win, 'winblend', 0)
-    close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" },
-        preview.border.win_id, { preview.bufnr }
-    )
-    close_preview_autocmd({ "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" },
-        help_win, { preview.bufnr }
+    vim.api.nvim_command(
+        "autocmd CursorMoved,CursorMovedI,BufHidden,BufLeave <buffer> ++once lua pcall(vim.api.nvim_win_close, "
+        .. help_win
+        .. ", true)"
     )
 end
 


### PR DESCRIPTION
Three problems with help menu (keybindings) in Neovim 0.8:
1. Incorect render borders
2. Error on close - `Error detected while processing CursorMoved Autocommands for "<buffer=35>": E5108: Error executing lua [string ":lua"]:1: attempt to call field '_close_preview_window' (a nil value)`
3. Error when toggle search hidden - `E5108: Error executing lua ...m/site/pack/packer/opt/nvim-spectre/lua/spectre/init.lua:549: attempt to get length of field 'search_query' (a nil value)` - when search field empty

Changes in thes pull request:
1. Remove border
2. Use `vim.api.nvim_win_close` to close popup
3. Use pcall to prevent E5108

