### PR TITLE
fix: use correct path separator for windows in open_file_search

### DIFF
--- a/lua/spectre/config.lua
+++ b/lua/spectre/config.lua
@@ -193,4 +193,10 @@ if vim.loop.os_uname().sysname == 'Darwin' then
         print("You need to install gnu sed 'brew install gnu-sed'")
     end
 end
+
+if vim.loop.os_uname().sysname == 'Windows_NT' then
+    if vim.fn.executable('sed') == 0 then
+        print("You need to install gnu sed with 'scoop install sed' or 'choco install sed'")
+    end
+end
 return config

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -50,9 +50,13 @@ M.open_visual = function(opts)
 end
 
 M.open_file_search = function()
-    M.open({
-        path = vim.fn.fnameescape(vim.fn.expand("%:p:."))
-    })
+    local path = vim.fn.fnameescape(vim.fn.expand('%:p:.'))
+
+    if vim.fn.has('win64') or vim.fn.has('win32') or vim.fn.has('win16') then
+        path = vim.fn.substitute(path, '\\', '/', 'g')
+    end
+
+    M.open({ path = path })
 end
 
 M.close = function()

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -52,7 +52,7 @@ end
 M.open_file_search = function()
     local path = vim.fn.fnameescape(vim.fn.expand('%:p:.'))
 
-    if vim.fn.has('win64') or vim.fn.has('win32') or vim.fn.has('win16') then
+    if vim.loop.os_uname().sysname == 'Windows_NT' then
         path = vim.fn.substitute(path, '\\', '/', 'g')
     end
 


### PR DESCRIPTION
Ripgrep is unable to find files/paths using the default path separator for Windows `\`.
Therefore replace the default separator with `/` so that path doesn't have to be edited manually when using `open_file_search`.

Also added a check of `sed` on Windows in `config.lua`