### PR TITLE
feat: add `:Spectre` command with vim plugin script

### DIFF
--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -171,7 +171,6 @@ function M.mapping_buffer(bufnr)
     api.nvim_buf_set_keymap(bufnr, 'n', 'd', '<nop>', map_opt)
     api.nvim_buf_set_keymap(bufnr, 'v', 'd', '<esc><cmd>lua require("spectre").toggle_checked()<cr>', map_opt)
     api.nvim_buf_set_keymap(bufnr, 'n', '?', "<cmd>lua require('spectre').show_help()<cr>", map_opt)
-    vim.api.nvim_command([[command! -nargs=* Spectre lua require("spectre").open()]])
 
     for _, map in pairs(state.user_config.mapping) do
         api.nvim_buf_set_keymap(bufnr, 'n', map.map, map.cmd, map_opt)

--- a/plugin/spectre.lua
+++ b/plugin/spectre.lua
@@ -1,0 +1,1 @@
+vim.api.nvim_command([[command! -nargs=* Spectre lua require("spectre").open()]])


### PR DESCRIPTION
It adds the `:Spectre` command not just when the buffer local mappings are created, but when vim plugin scripts are loaded i.e. you start out with being able to execute `:Spectre`.