### PR TITLE
Allow open_cmd override

### DIFF
--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -81,7 +81,8 @@ M.open = function(opts)
         replace_text = '',
         path = '',
         is_close = false, -- close an exists instance of spectre then open new
-        is_file = false
+        is_file = false,
+        open_cmd = nil
     }, opts or {}) or {}
 
     state.status_line = ''
@@ -105,7 +106,7 @@ M.open = function(opts)
         end
     end
     if state.bufnr == nil or is_new then
-        vim.cmd(state.user_config.open_cmd)
+        vim.cmd(opts.open_cmd or state.user_config.open_cmd)
     else
         if state.query.path ~= nil
             and #state.query.path > 1


### PR DESCRIPTION
This change allows `open_cmd` to be specified directly when opening a Spectre window.

Why?

I'm writing a little helper in my Neovim config that changes whether Spectre is opened horizontally or vertically depending on the window size. Since I regularly change between my Desktop and laptop, the aspect ratio of window changes, so I'd like for the command to be selectded dynamically. 🙂

``` lua
lvim.builtin.which_key.mappings["F"] = {
  function()
    local open_command = vim.fn.winwidth(0) / vim.fn.winheight(0) > 3.5 and "new" or "vnew"
    print(vim.fn.winwidth(0) / vim.fn.winheight(0), open_command)

    require("spectre").open({
      open_cmd = open_command,
      is_open_target_win = false,
      is_insert_mode = true,
      is_close = true,
    })
  end,
  "Find Text",
}

```