### PR TITLE
fix: use full path for filename

### DIFF
--- a/lua/spectre/actions.lua
+++ b/lua/spectre/actions.lua
@@ -17,10 +17,14 @@ local open_file = function(filename, lnum, col, winid)
 end
 
 local get_file_path = function(filename)
-    if state.cwd ~= nil and state.cwd ~= "" then
-        return vim.fn.expand(state.cwd) .. Path.path.sep .. filename
+
+    -- use default current working directory if state.cwd is nil or empty string
+    --
+    if state.cwd == nil or state.cwd == "" then 
+        state.cwd = vim.fn.getcwd()
     end
-    return filename
+
+    return vim.fn.expand(state.cwd) .. Path.path.sep .. filename
 end
 
 M.select_entry = function()


### PR DESCRIPTION
This patches fix https://github.com/nvim-pack/nvim-spectre/issues/106

It turns out the problem unrelated to the `nvim_win_set_cursor` but rather reference file in the search list buffer doesn't exists in the path, then it will open new empty buffer (just like creating new file buffer). Thus, it will expected that the reference cursor (col, row) doesn't exists in the new empty buffer.

With this patch, we just fill out `state.cwd` if its empty or nil (not exists) using current working directory (by `vim.fn.getcwd()` function). Thus, it will always refer to fullpath of referenced file.