### PR TITLE
feat: Add user highlight config for headers

### DIFF
--- a/lua/spectre/config.lua
+++ b/lua/spectre/config.lua
@@ -22,6 +22,7 @@ local config = {
     open_cmd           = 'vnew',
     live_update        = false,
     highlight          = {
+        headers = "Comment",
         ui = "String",
         filename = "Keyword",
         filedirectory = "Comment",

--- a/lua/spectre/ui.lua
+++ b/lua/spectre/ui.lua
@@ -143,7 +143,7 @@ function M.render_header(opts)
         opts.live_update and '(Auto update)' or '',
         state.user_config.default.replace.cmd
     )
-    utils.write_virtual_text(state.bufnr, config.namespace_header, 0, { { help_text, 'Comment' } })
+    utils.write_virtual_text(state.bufnr, config.namespace_header, 0, { { help_text, state.user_config.highlight.headers } })
 end
 
 M.show_menu_options = function(title, content)


### PR DESCRIPTION
Give user the option to change the highlight group for the header text