### PR TITLE
Fix resume last search

### DIFF
--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -272,7 +272,10 @@ M.on_close = function()
 end
 
 M.resume_last_search = function()
-    if not state.query_backup then return end
+    if not state.query_backup then 
+      print('No previous search!')
+      return 
+    end
     ui.render_text_query({
         replace_text = state.query_backup.replace_query,
         search_text = state.query_backup.search_query,

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -158,7 +158,7 @@ function M.mapping_buffer(bufnr)
                 au!
                 au InsertEnter <buffer> lua require"spectre".on_insert_enter()
                 au InsertLeave <buffer> lua require"spectre".on_search_change()
-                autocmd BufUnload <buffer> lua require("spectre").on_close()
+                autocmd BufLeave <buffer> lua require("spectre").on_close()
             augroup END ]]
     vim.opt_local.wrap = false
     vim.opt_local.foldexpr = "spectre#foldexpr()"


### PR DESCRIPTION
BufUnload was not firing the `on_close()` handler, which prevented the last search query from being saved.  This change uses the `BugLeave` event instead and prints a message to the mini buffer when no previous search criteria exists. 