### PR TITLE
feat(anti-insert-breakage)

### DIFF
--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -180,9 +180,9 @@ function M.mapping_buffer(bufnr)
     api.nvim_buf_set_keymap(bufnr, 'v', 'd', '<esc><cmd>lua require("spectre").toggle_checked()<cr>', map_opt)
     api.nvim_buf_set_keymap(bufnr, 'n', 'o', 'ji', map_opt) -- don't append line on can make the UI wrong
     api.nvim_buf_set_keymap(bufnr, 'n', 'O', 'ki', map_opt)
+    api.nvim_buf_set_keymap(bufnr, 'n', 'u', "", map_opt) -- disable undo, It breaks the UI
+    api.nvim_buf_set_keymap(bufnr, 'i', '<CR>', "", map_opt) -- disable ENTER on insert mode, it breaks the UI
     api.nvim_buf_set_keymap(bufnr, 'n', '?', "<cmd>lua require('spectre').show_help()<cr>", map_opt)
-    api.nvim_buf_set_keymap(bufnr, 'n', 'u', "", map_opt)
-    api.nvim_buf_set_keymap(bufnr, 'i', '<CR>', "", map_opt)
 
     for _, map in pairs(state.user_config.mapping) do
         api.nvim_buf_set_keymap(bufnr, 'n', map.map, map.cmd, vim.tbl_deep_extend("force", map_opt, { desc = map.desc }))

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -181,6 +181,7 @@ function M.mapping_buffer(bufnr)
     api.nvim_buf_set_keymap(bufnr, 'n', 'o', 'ji', map_opt) -- don't append line on can make the UI wrong
     api.nvim_buf_set_keymap(bufnr, 'n', 'O', 'ki', map_opt)
     api.nvim_buf_set_keymap(bufnr, 'n', '?', "<cmd>lua require('spectre').show_help()<cr>", map_opt)
+    api.nvim_buf_set_keymap(bufnr, 'n', 'u', "", map_opt)
     api.nvim_buf_set_keymap(bufnr, 'i', '<CR>', "", map_opt)
 
     for _, map in pairs(state.user_config.mapping) do

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -181,6 +181,7 @@ function M.mapping_buffer(bufnr)
     api.nvim_buf_set_keymap(bufnr, 'n', 'o', 'ji', map_opt) -- don't append line on can make the UI wrong
     api.nvim_buf_set_keymap(bufnr, 'n', 'O', 'ki', map_opt)
     api.nvim_buf_set_keymap(bufnr, 'n', '?', "<cmd>lua require('spectre').show_help()<cr>", map_opt)
+    api.nvim_buf_set_keymap(bufnr, 'i', '<CR>', "", map_opt)
 
     for _, map in pairs(state.user_config.mapping) do
         api.nvim_buf_set_keymap(bufnr, 'n', map.map, map.cmd, vim.tbl_deep_extend("force", map_opt, { desc = map.desc }))


### PR DESCRIPTION
This patch 

* Prevents BACKSPACE from breaking the UI by disabling the ability of BACKSPACE to jump lines by setting "set backspace=indent,start" (while filetype is spectre. Restores its previous value on WinLeave).
* Disables ENTER for insert mode on the spectre buffer. (this was added after recording the video).

[DEMO](https://www.youtube.com/watch?v=U6v4jCD_CMM)