### PR TITLE
fix: spectre buffer state incorrectly set when closing window

### DIFF
--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -205,6 +205,19 @@ function M.mapping_buffer(bufnr)
         callback = require('spectre').on_write,
         desc = "spectre write autocmd"
     })
+
+    vim.api.nvim_create_autocmd("BufWinLeave", {
+        group = vim.api.nvim_create_augroup("SpectrePanelClose", { clear = true }),
+        pattern = "*",
+        callback = function()
+            local current_filetype = vim.bo.filetype
+            if current_filetype == "spectre_panel" then
+                state.bufnr = nil
+            end
+        end,
+        desc = "spectre window close autocmd"
+    })
+
     -- Anti UI breakage
     -- * If the user enters insert mode on a forbidden line: leave insert mode. 
     -- * If the user passes over a forbidden line on insert mode: leave insert mode.


### PR DESCRIPTION
This fixes an issue where the toggle option (introduced in #143)  needs to be triggered twice when the the user manually closes the spectre window (e.g. `:quit`, `:close`, etc.).

<details>
<summary>Before</summary>

![Screen Recording 2023-07-09 at 10 34 04 PM](https://github.com/nvim-pack/nvim-spectre/assets/56745535/7493f29f-83e7-4edd-ae6d-899f24ef739c)

</details>

<details>
<summary>After</summary>

![Screen Recording 2023-07-09 at 10 34 37 PM](https://github.com/nvim-pack/nvim-spectre/assets/56745535/d0c25fcc-ab73-49be-bfff-96745fc8a645)

</details>
