### PR TITLE
fix(M.toggle) Dedicated state instead of re-using state.bufnr

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ You may need run `brew install gnu-sed`.
 ## Usage
 
 ```lua
-vim.keymap.set('n', '<leader>S', '<cmd>lua require("spectre").open()<CR>', {
-    desc = "Open Spectre"
+vim.keymap.set('n', '<leader>S', '<cmd>lua require("spectre").toggle()<CR>', {
+    desc = "Toggle Spectre"
 })
 vim.keymap.set('n', '<leader>sw', '<cmd>lua require("spectre").open_visual({select_word=true})<CR>', {
     desc = "Search current word"

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -73,7 +73,7 @@ M.close = function()
         for _, win_id in pairs(wins) do
             vim.api.nvim_win_close(win_id, true);
         end
-        state.bufnr = nil
+        state.opened = false
     end
 end
 
@@ -93,6 +93,7 @@ M.open = function(opts)
         is_file = false
     }, opts or {}) or {}
 
+    state.opened = true
     state.status_line = ''
     opts.search_text = utils.trim(opts.search_text)
     state.target_winid = api.nvim_get_current_win()
@@ -161,7 +162,7 @@ M.open = function(opts)
 end
 
 M.toggle = function(opts)
-    if state.bufnr ~= nil then M.close()
+    if state.opened then M.close()
     else M.open(opts) end
 end
 
@@ -202,6 +203,7 @@ function M.mapping_buffer(bufnr)
         callback = require('spectre').on_write,
         desc = "spectre write autocmd"
     })
+
     -- Anti UI breakage
     -- * If the user enters insert mode on a forbidden line: leave insert mode.
     -- * If the user passes over a forbidden line on insert mode: leave insert mode.

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -203,8 +203,8 @@ function M.mapping_buffer(bufnr)
         callback = require('spectre').on_write,
         desc = "spectre write autocmd"
     })
-    vim.api.nvim_create_autocmd({"WinClosed"}, {
-        group = vim.api.nvim_create_augroup("SpectreState", { clear = true }),
+    vim.api.nvim_create_autocmd("WinClosed", {
+        group = vim.api.nvim_create_augroup("SpectreStateOpened", { clear = true }),
         pattern = "*",
         callback = function()
             if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), 'filetype') == "spectre_panel" then

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -203,7 +203,16 @@ function M.mapping_buffer(bufnr)
         callback = require('spectre').on_write,
         desc = "spectre write autocmd"
     })
-
+    vim.api.nvim_create_autocmd({"WinClosed"}, {
+        group = vim.api.nvim_create_augroup("SpectreState", { clear = true }),
+        pattern = "*",
+        callback = function()
+            if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), 'filetype') == "spectre_panel" then
+                state.opened = false
+            end
+        end,
+        desc = "Ensure spectre state when its window is closed by any mean"
+    })
     -- Anti UI breakage
     -- * If the user enters insert mode on a forbidden line: leave insert mode.
     -- * If the user passes over a forbidden line on insert mode: leave insert mode.

--- a/lua/spectre/state.lua
+++ b/lua/spectre/state.lua
@@ -26,7 +26,8 @@ local state = {
     bufnr = nil,
     cwd = nil,
     target_winid = nil,
-    total_item = {}
+    total_item = {},
+    opened = false
 }
 
 if _G.__is_dev then


### PR DESCRIPTION
Fixes #150 

This PR fixes the state tracking of `M.toggle()` by using a dedicated state instead of re-using state.bufnr.

I also implemented the right autocmd to ensure the state is consistent no matter what command the user uses to close the spectre window (:bd, :bw, :close... anything goes).

So this should fix any possible issue related with toggle.