### PR TITLE
ci: package the plugin for lua(rocks)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: "release"
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          detailed_description: |
+            Find the enemy and replace them with dark power
+          dependencies: |
+            plenary.nvim
+          license: "mit"


### PR DESCRIPTION
### Summary
 
This PR is part of a push to get (neo)vim plugins on [LuaRocks](https://luarocks.org/labels/neovim).
 
* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.

 
 ### Things done:
 
* Add a workflow that publishes tags to LuaRocks when a tag is pushed.
 
 ### Notes
 
* Tagged releases are installed locally and then published to LuaRocks.org.
       On PRs, a test release is installed, but not published.
 
* For the release workflow to work, someone with a LuaRocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
 
* Due to a shortcoming in LuaRocks ([label doesn't get picked up from rockspec luarocks/luarocks-site#188](https://github.com/luarocks/luarocks-site/issues/188)), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in [luarocks.org/labels/neovim](https://luarocks.org/labels/neovim) or [luarocks.org/labels/vim](https://luarocks.org/labels/vim), respectively.
 
 cc @mrcjkb
 ![image](https://user-images.githubusercontent.com/12857160/258669184-ea7bd712-6227-486f-ba21-d9ba44de910c.png)
 
 **Adding the API key (screen shot)** ![github-add-luarocks-api-key](https://user-images.githubusercontent.com/12857160/211071297-afb129be-7a8f-4662-b282-9d52bb0286de.png)