### PR TITLE
feat: opts: begin_line_num

### DIFF
--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -90,7 +90,8 @@ M.open = function(opts)
         replace_text = '',
         path = '',
         is_close = false, -- close an exists instance of spectre then open new
-        is_file = false
+        is_file = false,
+        begin_line_num = 3
     }, opts or {}) or {}
 
     state.opened = true

--- a/lua/spectre/ui.lua
+++ b/lua/spectre/ui.lua
@@ -242,7 +242,7 @@ M.render_text_query = function(opts)
     api.nvim_buf_set_lines(state.bufnr, 2, 2, false, { opts.search_text })
     api.nvim_buf_set_lines(state.bufnr, 4, 4, false, { opts.replace_text })
     api.nvim_buf_set_lines(state.bufnr, 6, 6, false, { opts.path })
-    api.nvim_win_set_cursor(0, { 3, 0 })
+    api.nvim_win_set_cursor(0, { opts.begin_line_num or 3, 0 })
 end
 
 return M


### PR DESCRIPTION
I added a `begin_line_num` in `M.open`'s opts.
Every time I open the spectre with the givin word, the cursor position always in search placeholder, makes me need to move down multi lines to scan the result

Having this option, I set the keymap below, it feels so good
![image](https://github.com/nvim-pack/nvim-spectre/assets/50226652/e6ca3b81-a062-49e9-8646-b4ca41ec0910)
