### PR TITLE
Print errors from Sed replace command

### DIFF
--- a/lua/spectre/actions.lua
+++ b/lua/spectre/actions.lua
@@ -157,6 +157,11 @@ M.run_replace = function(entries)
             end
         end,
         on_error = function(result)
+            if type(result.value) == "string" then
+                for line in result.value:gmatch("[^\r\n]+") do
+                    print(line)
+                end
+            end
             if (result.ref) then
                 error_item = error_item + 1
                 local value = result.ref

--- a/lua/spectre/replace/base.lua
+++ b/lua/spectre/replace/base.lua
@@ -6,6 +6,7 @@ base.on_error = function(self, value, ref)
     if value ~= 0 then
         pcall(vim.schedule_wrap(function()
             self.handler.on_error({
+                value = value,
                 ref = ref
             })
         end))

--- a/lua/spectre/replace/sed.lua
+++ b/lua/spectre/replace/sed.lua
@@ -49,7 +49,10 @@ sed.replace = function(self, value)
         cwd = value.cwd,
         args = args,
         on_stdout = function(_, v) end,
-        on_stderr = function(_, v) self:on_error(v, value) end,
+        on_stderr = function(_, v)
+            v = self.state.cmd .. ' "' .. table.concat(args, '" "') .. '"\n' .. v
+            self:on_error(v, value)
+        end,
         on_exit = function(_, v) self:on_done(v, value) end
     })
     job:sync()


### PR DESCRIPTION
Currently, the errors from Sed aren't printed anywhere, which makes it hard to troubleshoot them. This commit prints the command, args, and stderr to help with that.