### PR TITLE
fix: Using a pcall prevents spectre from crashing if a hl group fail …

### DIFF
--- a/lua/spectre/ui.lua
+++ b/lua/spectre/ui.lua
@@ -95,6 +95,7 @@ M.render_filename = function(bufnr, namespace, line, entry)
     end
     local pos = 0
     for _, value in pairs(hl) do
+        pcall(function()
         api.nvim_buf_add_highlight(bufnr,
             namespace,
             value[2],
@@ -103,6 +104,7 @@ M.render_filename = function(bufnr, namespace, line, entry)
             pos + value[1][2]
         )
         pos = value[1][2] + pos
+      end)
     end
 end
 


### PR DESCRIPTION
This is a hot-fix that prevent spectre from crashing when a hl group fail to be generated in some files

## Pre-fix: spectre crashes
![screenshot_2023-10-06_18-41-32_635825568](https://github.com/nvim-pack/nvim-spectre/assets/3357792/1ca62f7a-8463-4554-8726-16b15b9a60be)

## Post-fix: spectre fails gracefuly
![screenshot_2023-10-06_18-41-13_102630000](https://github.com/nvim-pack/nvim-spectre/assets/3357792/ff63d82f-eddc-4d8e-9875-fe0e180f272a)

## More info
I've just added a pcall so it doesn't crash. But  if someone has time and energy to go into [this block of code](https://github.com/nvim-pack/nvim-spectre/blob/97cfd1b0f5a6ab35979ce1bee6c17f54745fd1e5/lua/spectre/ui.lua#L98) and see what's  going on, feel free.  IDK if it's worth it as the only side effect of this issue is that some result rows will show broken colors in the files affected by this (which idk how often happens or why).

We can open an issue and further research it if you want.