### PR TITLE
alternative 2 - ui-antibreakage by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ Thanks to everyone who sponsors my projects and makes continued development and 
 
 ## FAQ
 
+> [Spectre hardcodes some mappings in order to work correctly](https://github.com/nvim-pack/nvim-spectre/blob/1abe23ec9b7bc3082164f4cb842d521ef70e080e/lua/spectre/init.lua#L175). You can remap them as described above. You are allowed to create as many mappings as you want. For name and description choose any value. 'map' and 'cmd' are the only important fields.
+
 - How can I add a custom status line? [windline](https://github.com/windwp/windline.nvim)
 
 ```lua
@@ -334,11 +336,13 @@ Thanks to everyone who sponsors my projects and makes continued development and 
     )
 ```
 
-- How to avoid ui break?
+- How can I paste multi line text in the search box?
+
 ```lua
-require(spectre).setup({ is_block_ui_break = true })
+require(spectre).setup({ ui_breakage_protection = false })
 ```
-> [Spectre hardcodes some mappings in order to work correctly](https://github.com/nvim-pack/nvim-spectre/blob/1abe23ec9b7bc3082164f4cb842d521ef70e080e/lua/spectre/init.lua#L175). You can remap them as described above. You are allowed to create as many mappings as you want. For name and description choose any value. 'map' and 'cmd' are the only important fields.
+
+> Warning: This will allow you to break the UI. A maximum of 2 lines are allowed when pasting text in the search field. Pasting more than that will break the UX to the point of making it non functional.
 
 - Is spectre compatible with the plugin mini.animate?
 

--- a/lua/spectre/config.lua
+++ b/lua/spectre/config.lua
@@ -193,7 +193,7 @@ local config = {
     replace_vim_cmd    = "cdo",
     is_open_target_win = true,
     is_insert_mode     = false,
-    is_block_ui_break = false
+    ui_breakage_protection = true,
 }
 
 if vim.loop.os_uname().sysname == 'Darwin' then

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -214,7 +214,7 @@ function M.mapping_buffer(bufnr)
         desc = "Ensure spectre state when its window is closed by any mean"
     })
 
-    if state.user_config.is_block_ui_break then
+    if state.user_config.ui_breakage_protection then
         -- Anti UI breakage
         -- * If the user enters insert mode on a forbidden line: leave insert mode.
         -- * If the user passes over a forbidden line on insert mode: leave insert mode.


### PR DESCRIPTION
Fix for 411cee67fe3f8242023eb8d9edafefbbfb2d06f1
Related with #173

## Why merging this was this a mistake
I might be wrong but I don't think 411cee67fe3f8242023eb8d9edafefbbfb2d06f1 has been tested before been merged

* The supposed advantage of shipping `is_block_ui_break = false` by default was to allow multi line paste. But  this is not the case. It doesn't work: Pasting more than 2 lines will break the UI to the point of making it unusable.
* Preventing the user from breaking the UI should not be a opt in option. It is the minimum any user would expect from a program. If we need a better UI protection, we can work on that, but  I disagree with disabling it by default.

## Feedback needed
* This PR just re-enables the UI protection by default, but it keeps the option to disable it.

**I ship this because I don't feel good deleting the contribution of another person. But I strongly advise merging #175 instead of this PR**