### PR TITLE
Add support for search_paths option

### DIFF
--- a/lua/spectre/actions.lua
+++ b/lua/spectre/actions.lua
@@ -17,6 +17,11 @@ local open_file = function(filename, lnum, col, winid)
 end
 
 local get_file_path = function(filename)
+    -- if the path is absolute, return as is
+    -- TODO: need to handle Windows paths as well.
+    if string.sub(filename, 1, 1) == "/" then
+        return filename
+    end
     -- use default current working directory if state.cwd is nil or empty string
     --
     if state.cwd == nil or state.cwd == "" then

--- a/lua/spectre/actions.lua
+++ b/lua/spectre/actions.lua
@@ -16,10 +16,16 @@ local open_file = function(filename, lnum, col, winid)
     api.nvim_win_set_cursor(0, { lnum, col })
 end
 
+local is_absolute = function(filename)
+    if vim.loop.os_uname().sysname == "Windows_NT" then
+        return string.find(filename, "%a:\\") == 1
+    end
+    return string.sub(filename, 1, 1) == "/"
+end
+
 local get_file_path = function(filename)
     -- if the path is absolute, return as is
-    -- TODO: need to handle Windows paths as well.
-    if string.sub(filename, 1, 1) == "/" then
+    if is_absolute(filename) then
         return filename
     end
     -- use default current working directory if state.cwd is nil or empty string

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -144,6 +144,7 @@ M.open = function(opts)
 
 
     state.cwd = opts.cwd
+    state.search_paths = opts.search_paths
     M.change_view("reset")
     ui.render_search_ui()
 
@@ -641,7 +642,8 @@ M.search = function(opts)
     state.finder_instance:search({
         cwd = state.cwd,
         search_text = state.query.search_query,
-        path = state.query.path
+        path = state.query.path,
+        search_paths = state.search_paths,
     })
     M.init_regex()
 end

--- a/lua/spectre/search/base.lua
+++ b/lua/spectre/search/base.lua
@@ -104,10 +104,16 @@ base.search = function(self, query)
         query.cwd = nil
     end
     table.insert(args, query.search_text)
+    if query.search_paths then
+        for _, dir in ipairs(query.search_paths) do
+            table.insert(args, dir)
+        end
+    else
+        -- https://github.com/nvim-telescope/telescope.nvim/issues/907
+        -- ripgrep issue
+        -- table.insert(args, '.')
+    end
 
-    -- https://github.com/nvim-telescope/telescope.nvim/issues/907
-    -- ripgrep issue
-    table.insert(args, '.')
 
     log.debug("search cwd " .. (query.cwd or ''))
     log.debug("search: " .. self.state.cmd .. ' ' .. table.concat(args, ' '))

--- a/lua/spectre/search/base.lua
+++ b/lua/spectre/search/base.lua
@@ -111,7 +111,7 @@ base.search = function(self, query)
     else
         -- https://github.com/nvim-telescope/telescope.nvim/issues/907
         -- ripgrep issue
-        -- table.insert(args, '.')
+        table.insert(args, '.')
     end
 
 


### PR DESCRIPTION
Hi,

Thanks for the great plugin!

This is a proposed fix for #184. Currently, spectre always searches in the `cwd`, it launches the job with a given `cwd` and then passes `.` to the search tool.

Unfortunately, this does not work for large directories, such as monorepos. In a monorepo, you usually work in a number of different directories depending on the current project. So it is convenient to search in the scope of those directories.

Note that the `path` option in the spectre does not solve the issue. The search is still performed in the `cwd`, but only the files matched by the `path` glob are used for searching. But the search tool still needs to list the files recursively in the entire monorepo, which is very slow.

This PR adds another option to the configuration called `search_paths`. The search paths are then passed to the search tool, instead of the `.`.

Also need to fix the opening of the file. When searched like this, the returned file paths could be absolute, so we don't need to make a relative path to the `cwd`.