### PR TITLE
show line number for each result text

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ require('spectre').setup({
   color_devicons = true,
   open_cmd = 'vnew',
   live_update = false, -- auto execute search again when you write to any file in vim
+  lnum_for_results = true, -- show line number for search/replace results
   line_sep_start = '┌-----------------------------------------',
   result_padding = '¦  ',
   line_sep       = '└-----------------------------------------',

--- a/doc/spectre.txt
+++ b/doc/spectre.txt
@@ -121,6 +121,7 @@ default settings.
       color_devicons = true,
       open_cmd = 'vnew',
       live_update = false, -- auto execute search again when you write to any file in vim
+      lnum_for_results = true, -- show line number for search/replace results
       line_sep_start = '┌-----------------------------------------',
       result_padding = '¦  ',
       line_sep       = '└-----------------------------------------',

--- a/lua/spectre/config.lua
+++ b/lua/spectre/config.lua
@@ -24,6 +24,7 @@ local config = {
     color_devicons     = true,
     open_cmd           = 'vnew',
     live_update        = false,
+    lnum_for_results   = true, -- show line number for search/replace results
     highlight          = {
         headers = "SpectreHeader",
         ui = "SpectreBody",

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -557,6 +557,7 @@ M.search_handler = function()
                     replace_query = state.query.replace_query,
                     search_text = item.search_text,
                     lnum = item.display_lnum,
+                    item_line = item.lnum,
                     is_replace = false
                 },
                 {

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -388,6 +388,7 @@ M.do_replace_text = function(opts, async_id)
                 replace_query = state.query.replace_query,
                 search_text = item.search_text,
                 lnum = item.display_lnum,
+                item_line = item.lnum,
                 is_replace = true,
             },
             {
@@ -456,6 +457,7 @@ M.toggle_line = function(line_visual)
                 replace_query = state.query.replace_query,
                 search_text = item.search_text,
                 lnum = item.display_lnum,
+                item_line = item.lnum,
                 is_replace = true
             },
             {
@@ -489,6 +491,7 @@ M.toggle_line = function(line_visual)
                         replace_query = state.query.replace_query,
                         search_text = item.search_text,
                         lnum = item.display_lnum,
+                        item_line = item.lnum,
                         is_replace = true
                     },
                     {

--- a/lua/spectre/ui.lua
+++ b/lua/spectre/ui.lua
@@ -23,6 +23,7 @@ M.render_line = function(bufnr, namespace, text_opts, view_opts, regex)
         show_replace = view_opts.show_replace,
     }, regex)
     local end_lnum = text_opts.is_replace == true and text_opts.lnum + 1 or text_opts.lnum
+    local item_line_len = string.len(text_opts.item_line) + 1
     api.nvim_buf_set_lines(bufnr, text_opts.lnum, end_lnum, false, {
         view_opts.padding_text .. text_opts.item_line .. " " .. diff.text,
     })
@@ -30,12 +31,12 @@ M.render_line = function(bufnr, namespace, text_opts, view_opts, regex)
         for _, value in pairs(diff.search) do
             api.nvim_buf_add_highlight(bufnr, namespace,
                 cfg.highlight.search,
-                text_opts.lnum, value[1] + view_opts.padding, value[2] + view_opts.padding)
+                text_opts.lnum, value[1] + view_opts.padding + item_line_len, value[2] + view_opts.padding + item_line_len)
         end
         for _, value in pairs(diff.replace) do
             api.nvim_buf_add_highlight(bufnr, namespace,
                 cfg.highlight.replace,
-                text_opts.lnum, value[1] + view_opts.padding, value[2] + view_opts.padding)
+                text_opts.lnum, value[1] + view_opts.padding + item_line_len, value[2] + view_opts.padding + item_line_len)
         end
         api.nvim_buf_add_highlight(state.bufnr, config.namespace,
             cfg.highlight.border, text_opts.lnum, 0, view_opts.padding)

--- a/lua/spectre/ui.lua
+++ b/lua/spectre/ui.lua
@@ -23,10 +23,19 @@ M.render_line = function(bufnr, namespace, text_opts, view_opts, regex)
         show_replace = view_opts.show_replace,
     }, regex)
     local end_lnum = text_opts.is_replace == true and text_opts.lnum + 1 or text_opts.lnum
-    local item_line_len = string.len(text_opts.item_line) + 1
-    api.nvim_buf_set_lines(bufnr, text_opts.lnum, end_lnum, false, {
-        view_opts.padding_text .. text_opts.item_line .. " " .. diff.text,
-    })
+
+    local item_line_len = 0
+    if cfg.lnum_for_results == true then
+        item_line_len = string.len(text_opts.item_line) + 1
+        api.nvim_buf_set_lines(bufnr, text_opts.lnum, end_lnum, false, {
+            view_opts.padding_text .. text_opts.item_line .. " " .. diff.text,
+        })
+    else
+        api.nvim_buf_set_lines(bufnr, text_opts.lnum, end_lnum, false, {
+            view_opts.padding_text .. diff.text,
+        })
+    end
+
     if not view_opts.is_disable then
         for _, value in pairs(diff.search) do
             api.nvim_buf_add_highlight(bufnr, namespace,

--- a/lua/spectre/ui.lua
+++ b/lua/spectre/ui.lua
@@ -24,7 +24,7 @@ M.render_line = function(bufnr, namespace, text_opts, view_opts, regex)
     }, regex)
     local end_lnum = text_opts.is_replace == true and text_opts.lnum + 1 or text_opts.lnum
     api.nvim_buf_set_lines(bufnr, text_opts.lnum, end_lnum, false, {
-        view_opts.padding_text .. diff.text,
+        view_opts.padding_text .. text_opts.item_line .. " " .. diff.text,
     })
     if not view_opts.is_disable then
         for _, value in pairs(diff.search) do
@@ -81,7 +81,7 @@ M.render_filename = function(bufnr, namespace, line, entry)
         state.user_config.color_devicons, '+')
 
     api.nvim_buf_set_lines(state.bufnr, line, line, false, {
-        string.format("%s %s%s:%s:%s:", icon, directory, filename, entry.lnum, entry.col),
+        string.format("%s %s%s:", icon, directory, filename),
     })
 
     local width = vim.api.nvim_strwidth(filename)


### PR DESCRIPTION
Hi, this plugin is so wonderful and I use it everyday. And I found an bug (if we can call it a bug) for the line number, the pull request is used to fix it.

During the search, if there are more than one result found in the same file, we can only see the the line/column numbers of the first matched result showing behand the filename. 
Here is an examle:
![image](https://github.com/nvim-pack/nvim-spectre/assets/13688920/22dfae42-79b2-46f6-8e17-a1eaba42ef4b)

I think it is useless, because we still can't know the line number of each matched result.
The following formats is more useful. we can see which file the results belong to, and we can also know the line number of each result. 
![image](https://github.com/nvim-pack/nvim-spectre/assets/13688920/a2957354-c377-4063-b560-c55b5566d76d)

This pull request is used to show the new formats, please help to check it.