### PR TITLE
Update build.sh to fail if build fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 cd spectre_oxi
 
 cargo build --release


### PR DESCRIPTION
Build issues such as https://github.com/nvim-pack/nvim-spectre/issues/185 are not reflected in the exit status so it silently fails when building. Updating this to fail allows plugin managers like lazy.nvim to identify the failed build