### PR TITLE
add support to pcre2 operations

### DIFF
--- a/spectre_oxi/Cargo.lock
+++ b/spectre_oxi/Cargo.lock
@@ -12,6 +12,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,18 +139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,9 +190,9 @@ dependencies = [
 name = "spectre_oxi"
 version = "0.1.0"
 dependencies = [
+ "fancy-regex",
  "lazy_static",
  "nvim-oxi",
- "regex",
 ]
 
 [[package]]

--- a/spectre_oxi/Cargo.toml
+++ b/spectre_oxi/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 nvim-oxi = { version = "0.3.0", features=["neovim-0-9"] }
-regex = "1.6.0"
+fancy-regex = "0.13.0"
 lazy_static = "1.4.0"
 


### PR DESCRIPTION
Hello everyone, everything good? I would like to propose a simple change in the way "oxi" implements regex, I recently came across a problem, I need to replace the import of some libraries for a specific pattern, but I only managed to get a satisfactory regex using an operator called negative lookahead operator, although ripgrep already has support if we use the `--pcre2` flag, `sed` and not even `oxi` supports these operators by default, by researching a little it is possible to see that oxy uses the rust regex lib, however, it does not support pcre2 operations, but I found a call `fancy_regex` that supports "pcre2" operators which is very similar to regex, and I just made a small change in the "matchstr" function and now it is possible for operators to use pcre2 without any problem , ripgrep already supports this type of operator, it is very simple to support this implementation in the plugin configuration, here is an example:

```lua
return {
  "nvim-pack/nvim-spectre",
  opts = {
    default = {
      replace = {
        cmd = "oxi",
      },
    },
    find_engine = {
      ["rg"] = {
        cmd = "rg",
        args = {
          "--pcre2",
          "--color=never",
          "--no-heading",
          "--with-filename",
          "--line-number",
          "--column",
        },
      },
    },
  },
}
```