### PR TITLE
build: add apple-darwin rustflags

### DIFF
--- a/spectre_oxi/.cargo/config.toml
+++ b/spectre_oxi/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]


### PR DESCRIPTION
nvim-oxi has [those exact flags](https://github.com/noib3/nvim-oxi/blob/c9a71b0e5c4edc4f0916a5d0fb20d73bce0c52ef/.cargo/config.toml), I'm adding those here to support NixOS on darwin (see https://github.com/NixOS/nixpkgs/pull/314639).