### PR TITLE
feat: config to silence executable warnings

### DIFF
--- a/doc/spectre.txt
+++ b/doc/spectre.txt
@@ -273,6 +273,7 @@ default settings.
                   icon="[I]",
                   desc="ignore case"
                 },
+                warn = true,
               }
           },
           -- call rust code by nvim-oxi to replace
@@ -290,6 +291,7 @@ default settings.
           ['sd'] = {
             cmd = "sd",
             options = { },
+            warn = true,
           },
       },
       default = {
@@ -314,6 +316,20 @@ default settings.
       }
     })
 <
+Warnings are emitted based on your operating system and chosen executables. If
+you find one of these warnings to be in error, you may silence it by setting
+the respective `warn` key. For example, to silence GNU sed warnings:
+
+>
+    require('spectre').setup({
+        replace_engine={
+            ['sed']={
+                  warn = false,
+                }
+            },
+        }
+    })
+>
 
 
 CUSTOM FUNCTIONS ~

--- a/lua/spectre/config.lua
+++ b/lua/spectre/config.lua
@@ -189,6 +189,7 @@ local config = {
                     desc = 'ignore case',
                 },
             },
+            warn = true,
         },
         ['oxi'] = {
             cmd = 'oxi',
@@ -204,6 +205,7 @@ local config = {
         ['sd'] = {
             cmd = 'sd',
             options = {},
+            warn = true,
         },
     },
     default = {

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -45,20 +45,20 @@ M.check_replace_cmd_bins = function()
     if state.user_config.default.replace.cmd == 'sed' then
         if vim.loop.os_uname().sysname == 'Darwin' then
             config.replace_engine.sed.cmd = 'gsed'
-            if vim.fn.executable('gsed') == 0 then
+            if vim.fn.executable('gsed') == 0 and state.user_config.replace_engine.sed.warn then
                 print("You need to install gnu sed 'brew install gnu-sed'")
             end
         end
 
         if vim.loop.os_uname().sysname == 'Windows_NT' then
-            if vim.fn.executable('sed') == 0 then
+            if vim.fn.executable('sed') == 0 and state.user_config.replace_engine.sed.warn then
                 print("You need to install gnu sed with 'scoop install sed' or 'choco install sed'")
             end
         end
     end
 
     if state.user_config.default.replace.cmd == 'sd' then
-        if vim.fn.executable('sd') == 0 then
+        if vim.fn.executable('sd') == 0 and state.user_config.replace_engine.sd.warn then
             print("You need to install or build 'sd' from: https://github.com/chmln/sd")
         end
     end


### PR DESCRIPTION
I'm on macOS and, although the `sed` on my path is GNU sed, I still see the "You need to install gnu sed 'brew install gnu-sed'" warning. This is because the plugin assumes macOS users will be using the Homebrew package manager and thus checks for the `gsed` executable. While this is a safe assumption for many (most?) macOS users, folks who are using other package managers, have aliased `sed` to `gsed`, etc. will see false positives.

I worked around this in a rather simple way, by adding a `warn` option that the user can simply set to false if they know better than the plugin. From the doc update:

> Warnings are emitted based on your operating system and chosen executables. If you find one of these warnings to be in error, you may silence it by setting the respective `warn` key. For example, to silence GNU sed warnings:

```lua
require('spectre').setup({
    replace_engine={
        ['sed']={
              warn = false,
            }
        },
    }
})
```

A medium-confidence check for GNU sed, e.g. testing for the existence of the `--version` flag, could be employed but that adds some execution overhead and a bit more complexity than the solution I'm proposing. Thoughts?