### PR TITLE
feat: lazy load spectre core for the command

### DIFF
--- a/plugin/spectre.lua
+++ b/plugin/spectre.lua
@@ -1,5 +1,3 @@
-local spectre = require("spectre")
-
 local function get_arg(str)
 	local key, value = str:match([=[^([^%s]*)=([^%s]*)$]=])
 
@@ -11,6 +9,7 @@ local function get_arg(str)
 end
 
 vim.api.nvim_create_user_command("Spectre", function(ctx)
+    local spectre = require("spectre")
 	local args = {}
 	local user_args
 	if #ctx.fargs == 1 or vim.tbl_isempty(ctx.fargs) then


### PR DESCRIPTION
Hello

Currently the file `plugin/spectre.lua` execution takes just over 12.2ms on my laptop. I found it surprising giving that it only sets a single command. Making this small adjustment the execution time drops to 0.28ms. While 12ms is not a big difference this file is being sourced automatically at start up and it would be preferred to not block the startup by default when possible.

Hope this helps and thanks for your work