### PR TITLE
feat: allow open_cmd to be a lua function

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ the default settings.
 require('spectre').setup({
 
   color_devicons = true,
-  open_cmd = 'vnew',
+  open_cmd = 'vnew', -- can also be a lua function
   live_update = false, -- auto execute search again when you write to any file in vim
   lnum_for_results = true, -- show line number for search/replace results
   line_sep_start = '┌-----------------------------------------',

--- a/doc/spectre.txt
+++ b/doc/spectre.txt
@@ -122,7 +122,7 @@ default settings.
     require('spectre').setup({
     
       color_devicons = true,
-      open_cmd = 'vnew',
+      open_cmd = 'vnew', -- can also be a lua function
       live_update = false, -- auto execute search again when you write to any file in vim
       lnum_for_results = true, -- show line number for search/replace results
       line_sep_start = '┌-----------------------------------------',

--- a/lua/spectre/init.lua
+++ b/lua/spectre/init.lua
@@ -152,7 +152,11 @@ M.open = function(opts)
         end
     end
     if state.bufnr == nil or is_new then
-        vim.cmd(state.user_config.open_cmd)
+        if type(state.user_config.open_cmd) == 'function' then
+            state.user_config.open_cmd()
+        else
+            vim.cmd(state.user_config.open_cmd)
+        end
     else
         if state.query.path ~= nil and #state.query.path > 1 and opts.path == '' then
             opts.path = state.query.path


### PR DESCRIPTION
Not sure if this change is desirable, but I found it useful to open Spectre in a floating window in my own config.
Feel free to close this if you think it is a bad change.