### PR TITLE
updates sed in-place args to support macOS

### DIFF
--- a/lua/spectre/config.lua
+++ b/lua/spectre/config.lua
@@ -178,10 +178,7 @@ local config = {
     replace_engine = {
         ['sed'] = {
             cmd = 'sed',
-            args = {
-                '-i',
-                '-E',
-            },
+            args = nil,
             options = {
                 ['ignore-case'] = {
                     value = '--ignore-case',

--- a/lua/spectre/replace/sed.lua
+++ b/lua/spectre/replace/sed.lua
@@ -5,13 +5,18 @@ local log = require('spectre._log')
 local sed = {}
 
 sed.init = function(_, config)
+    local uname = vim.loop.os_uname().sysname
+    local sed_args
+    if uname == 'Darwin' then
+        sed_args = { '-i', '', '-e' }
+    else
+        sed_args = { '-i', '-E' }
+    end
+
     config = vim.tbl_extend('force', {
         cmd = 'sed',
         pattern = '%s,%ss/%s/%s/g',
-        args = {
-            '-i',
-            '-E',
-        },
+        args = sed_args,
     }, config or {})
     return config
 end


### PR DESCRIPTION
Fixes the issue of in-place replacement on macOS by not creating files ending with mistakenly accepting `-E` arg as part of `-i -E` as macOS sed requires an empty pair of quotes like so `-i "" -E`  (related issue #259 ):

FIx removes default args in `config.lua` and updates `sed` args to be determined by `Darwin` (macOS) vs others.