### PR TITLE
Use POSIX shell for build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -8,12 +8,12 @@ cargo build --release
 
 [ "$CARGO_TARGET_DIR" = "" ] && CARGO_TARGET_DIR=target
 
-if [ "$(uname)" == "Darwin" ]; then
-    cp "$CARGO_TARGET_DIR"/release/libspectre_oxi.dylib ../lua/spectre_oxi.so
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    cp "$CARGO_TARGET_DIR"/release/libspectre_oxi.so ../lua/spectre_oxi.so
-elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
-    cp "$CARGO_TARGET_DIR"/release/libspectre_oxi.dll ../lua/spectre_oxi.dll
+if [ "$(uname)" = "Darwin" ]; then
+    cp -f "$CARGO_TARGET_DIR"/release/libspectre_oxi.dylib ../lua/spectre_oxi.so
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
+    cp -f "$CARGO_TARGET_DIR"/release/libspectre_oxi.so ../lua/spectre_oxi.so
+elif [ "$(expr substr $(uname -s) 1 10)" = "MINGW32_NT" ]; then
+    cp -f "$CARGO_TARGET_DIR"/release/libspectre_oxi.dll ../lua/spectre_oxi.dll
 fi
 rm -rf target
 echo "Build Done"


### PR DESCRIPTION
`/bin/bash` doesn't exist in some niche Linux OSs like Guix or NixOS, but `/bin/sh` does. This PR updates the build script to use POSIX shell syntax by replacing `==` with `=`. I also added `-f` flag for all cp commands, so the script can be invoked without fail.